### PR TITLE
Updated the code to reverse the arc

### DIFF
--- a/dialog.rb
+++ b/dialog.rb
@@ -29,7 +29,7 @@ module EA_Extensions623
         end
 
         options = {
-          :title           => 'Wide Flange Steel',
+          :title           => "Wide Flange Steel #{VERSION_NUM}",
           :preferences_key => 'WFS',
           :width           => 400,
           :height          => 460,

--- a/dialog_rolled.rb
+++ b/dialog_rolled.rb
@@ -47,7 +47,7 @@ module EA_Extensions623
         end
 
         @options = {
-          :title           => 'Wide Flange Steel v1.0', #change the version number with ever y cahnge
+          :title           => "Wide Flange Steel #{VERSION_NUM}" , #change the version number with ever y cahnge
           :preferences_key => 'WFS',
           :width           => 400,
           :height          => 480,


### PR DESCRIPTION
If the arc is backwards then the cod eflips the arc so the labels work.
this only helps when the roll type is 'EASY' labels still go backwards
if the roll type is 'HARD'